### PR TITLE
Global options page

### DIFF
--- a/admin/options.php
+++ b/admin/options.php
@@ -1,0 +1,11 @@
+<?php
+
+if (function_exists('acf_add_options_page')) {
+    acf_add_options_page(array(
+        'page_title'    => 'Global Options',
+        'menu_title'    => 'Global Options',
+        'menu_slug'     => 'global-options',
+        'capability'    => 'edit_posts',
+        'redirect'      => false
+    ));
+}

--- a/admin/options.php
+++ b/admin/options.php
@@ -2,9 +2,9 @@
 
 if (function_exists('acf_add_options_page')) {
     acf_add_options_page(array(
-        'page_title'    => 'Global Options',
-        'menu_title'    => 'Global Options',
-        'menu_slug'     => 'global-options',
+        'page_title'    => 'Site Options',
+        'menu_title'    => 'Site Options',
+        'menu_slug'     => 'site-options',
         'capability'    => 'edit_posts',
         'redirect'      => false
     ));

--- a/assets/src/css/organisms/footer.css
+++ b/assets/src/css/organisms/footer.css
@@ -6,4 +6,14 @@
         align-items: center;
         justify-content: space-between;
     }
+
+    .social {
+        font-size: 2.2rem;
+
+        a {
+            &:hover {
+                opacity: 0.8;
+            }
+        }
+    }
 }

--- a/functions.php
+++ b/functions.php
@@ -20,6 +20,7 @@ add_action(
 
         include_once 'config.php';
         include_once 'admin/global.php';
+        include_once 'admin/options.php';
 
         if (is_user_logged_in()) {
             update_user_option_admin_color();

--- a/functions.php
+++ b/functions.php
@@ -62,10 +62,10 @@ add_action(
 
         //auto load scripts
         //change to get_stylesheet_directory for child theme
-        foreach (glob( __DIR__ . "/config/*.php") as $filename) {
+        foreach (glob(__DIR__ . "/config/*.php") as $filename) {
             require_once($filename);
         }
-        foreach (glob( __DIR__ . "/hooks/*.php") as $filename) {
+        foreach (glob(__DIR__ . "/hooks/*.php") as $filename) {
             require_once($filename);
         }
 

--- a/models/Options.php
+++ b/models/Options.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace CatalystWP\Atom\models;
+
+class Options
+{
+    /**
+     * Setup array of options
+     */
+    public static function setOptions()
+    {
+        if (!function_exists('get_field')) {
+            return;
+        }
+
+        $options = get_fields('option');
+        return $options;
+    }
+}

--- a/models/Organisms.php
+++ b/models/Organisms.php
@@ -91,7 +91,6 @@ class Organisms extends \CatalystWP\Nucleus\Model
          * Use {{{gform}}} within template to render form
          */
         if (!empty($organism['form'])) {
-
             //support for newer version of gravity form ACF field plugin
             if (is_array($organism['form_id']) && isset($organism['form_id']['id'])) {
                 $organism['form_id'] = $organism['form_id']['id'];

--- a/models/organisms/Footer.php
+++ b/models/organisms/Footer.php
@@ -3,6 +3,7 @@
 namespace CatalystWP\Atom\models\organisms;
 
 use CatalystWP\Nucleus\models\Menu as Menu;
+use CatalystWP\Atom\models\Options as Options;
 
 class Footer extends \CatalystWP\Nucleus\Model
 {
@@ -10,5 +11,6 @@ class Footer extends \CatalystWP\Nucleus\Model
     {
         $this->menu = new Menu('primary');
         $this->year = date('Y');
+        $this->options = Options::setOptions();
     }
 }

--- a/templates/organisms/footer.handlebars
+++ b/templates/organisms/footer.handlebars
@@ -2,8 +2,16 @@
     {{#with footer}}
     <div class="organism footer" id="footer">
         <div class="container">
-            <p>&copy; {{year}} Bokka Group</p>
+            <p>&copy; {{year}} {{options.company_name}}</p>
             {{> molecules/menu}}
+
+            {{#if options.social_media_links}}
+                <div class="social">
+                    {{#each options.social_media_links}}
+                        {{> atoms/fa-icon}}
+                    {{/each}}
+                </div>
+            {{/if}}
         </div><!--/container-->
     </div><!--/footer-->
     {{/with}}


### PR DESCRIPTION
I ended up using the ACF options page functionality to set this up, which I think will provide more flexibility than having pre-defined options fields built into the theme.

Here's an [acf-export-2018-02-28 (1).json.zip](ACF export) with some basic fields, which are what I'm using in the footer template.
